### PR TITLE
Add library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,10 @@
+name=smart-blaster
+version=0.8.0
+author=etnom
+maintainer=etnom
+sentence=Ammo counters and more for modified NERF blasters.
+paragraph=Completely outclass your opponents at your next NERF war.
+category=Other
+url=https://github.com/etnom/smart-blaster
+architectures=*
+includes=SmartBlaster.h


### PR DESCRIPTION
This file is required for the Arduino IDE to recognize the library. Without this file the library is unusable in the Arduino IDE.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification

Fixes https://github.com/etnom/smart-blaster/issues/1